### PR TITLE
Use Figaro.env var for production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = Figaro.env.assets.compile
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
@@ -49,7 +49,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = Figaro.env.log_level
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -74,16 +74,16 @@ Hyrax.config do |config|
   # config.noid_minter_class = ActiveFedora::Noid::Minter::Db
 
   # Store identifier minter's state in a file for later replayability
-  # config.minter_statefile = '/tmp/minter-state'
+  config.minter_statefile = Figaro.env.minter_statefile
 
   # Prefix for Redis keys
-  # config.redis_namespace = "hyrax"
+  config.redis_namespace = Figaro.env.redis_namespace
 
   # Path to the file characterization tool
-  # config.fits_path = "fits.sh"
+  config.fits_path = Figaro.env.fits_path
 
   # Path to the file derivatives creation tool
-  # config.libreoffice_path = "soffice"
+  config.libreoffice_path = Figaro.env.libreoffice_path
 
   # Option to enable/disable full text extraction from PDFs
   # Default is true, set to false to disable full text extraction
@@ -97,7 +97,7 @@ Hyrax.config do |config|
   # config.arkivo_api = false
 
   # Stream realtime notifications to users in the browser
-  # config.realtime_notifications = true
+  config.realtime_notifications = Figaro.env.realtime_notifications
 
   # Location autocomplete uses geonames to search for named regions
   # Username for connecting to geonames
@@ -132,7 +132,7 @@ Hyrax.config do |config|
 
   # Location on local file system where derivatives will be stored
   # If you use a multi-server architecture, this MUST be a shared volume
-  # config.derivatives_path = Rails.root.join('tmp', 'derivatives')
+  config.derivatives_path = Figaro.env.derivatives_path
 
   # Should schema.org microdata be displayed?
   # config.display_microdata = true


### PR DESCRIPTION
Add more Figaro env variables to configure Hyrax initilise file:
- minter statfle location
- derivatives location
- fits.sh path
- soffice path
- reltime notification
- redis namspace for OASIS

And enviroemtns production
- dynamic asset compile
- log levels