### PR TITLE
[WIP] Disable use of Redis asynchronous job in staging/production environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -62,7 +62,7 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.active_job.queue_adapter     = :resque
-  config.active_job.queue_name_prefix = "oasis_#{Rails.env}"
+  # config.active_job.queue_adapter     = :resque
+  # config.active_job.queue_name_prefix = "oasis_#{Rails.env}"
 
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,6 +39,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
-  config.active_job.queue_adapter     = :resque
-  config.active_job.queue_name_prefix = "oasis_#{Rails.env}"
+  # config.active_job.queue_adapter     = :resque
+  # config.active_job.queue_name_prefix = "oasis_#{Rails.env}"
 end

--- a/config/initializers/redis_config.rb
+++ b/config/initializers/redis_config.rb
@@ -1,4 +1,4 @@
 require 'redis'
 config = YAML.safe_load(ERB.new(IO.read(Rails.root.join('config', 'redis.yml'))).result)[Rails.env].with_indifferent_access
 Redis.current = Redis.new(config.merge(thread_safe: true))
-Resque.redis = Redis.current
+# Resque.redis = Redis.current


### PR DESCRIPTION
Related to #149 

Disable resque as workers require further configuration.

With misconfigured Resque workers ingest of binary files does not work correctly.