### PR TITLE
[WIP] Correction to #207 disable resque

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,8 +60,6 @@ Rails.application.configure do
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "oasis_#{Rails.env}"
-  config.active_job.queue_adapter     = :resque
-  config.active_job.queue_name_prefix = "oasis_#{Rails.env}"
 
   config.action_mailer.perform_caching = false
 


### PR DESCRIPTION
Disable use of Redis asynchronous job in staging/production environment. 

Include production env as it was accidentally omitted in #207 