### PR TITLE
Issue 222 make metadata fields clickable

### DIFF
--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -33,7 +33,7 @@
                 <% if GenericLocalAuthorityService.id_to_label('research_areas',ra.to_i).include? 'Other' %>
                     <% if GenericLocalAuthorityService.id_to_label('research_areas',ra.to_i)!='Other' %>
                         <%= link_to  GenericLocalAuthorityService.id_to_label('research_areas',ra.to_i),
-                                  '/catalog?f[research_areas_sim][]='+ra+'&locale=en&q=&search_field=all_fields',
+                                  '/catalog?f[summary_general_research_area_sim][]='+ra+'&locale=en&q=&search_field=all_fields',
                                      :target => "_blank"
                       %>
                     <% else %>
@@ -48,7 +48,7 @@
                     </ul>
                 <% else %>
                     <%= link_to  GenericLocalAuthorityService.id_to_label('research_areas',ra.to_i),
-                                  '/catalog?f[research_areas_sim][]='+ra+'&locale=en&q=&search_field=all_fields',
+                                  '/catalog?f[summary_general_research_area_sim][]='+ra+'&locale=en&q=&search_field=all_fields',
                                   :target => "_blank"
                   %>
                     <br/>
@@ -65,7 +65,35 @@
         %>
         <tr>
           <th><span class="attribute-label h4">Participant type</span></th>
-          <td><%= sanitize(v) %></td>
+          <td>
+
+            <% pts.each do |pt| %>
+                <% if GenericLocalAuthorityService.id_to_label('participant_types',pt.to_i).include? 'Other' %>
+                    <% if GenericLocalAuthorityService.id_to_label('participant_types',pt.to_i)!='Other' %>
+                        <%= link_to  GenericLocalAuthorityService.id_to_label('participant_types',pt.to_i),
+                                     '/catalog?f[participants_type_sim][]='+ra+'&locale=en&q=&search_field=all_fields',
+                                     :target => "_blank"
+                        %>
+                    <% else %>
+                        <%= GenericLocalAuthorityService.id_to_label('participant_types',pt.to_i) %><br/>
+                    <% end %>
+                    <ul>
+                      <%unless doc_presenter.document._source["participants_type_other_tesim"].nil?%>
+                          <%doc_presenter.document._source["participants_type_other_tesim"].each do |w|%>
+                              <li><%=w%></li>
+                          <%end%>
+                      <%end%>
+                    </ul>
+                <% else %>
+                    <%= link_to  GenericLocalAuthorityService.id_to_label('participant_types',pt.to_i),
+                                 '/catalog?f[participants_type_sim][]='+pt+'&locale=en&q=&search_field=all_fields',
+                                 :target => "_blank"
+                    %>
+                    <br/>
+                <% end %>
+            <% end %>
+
+          </td>
         </tr>
 
         <!-- Participant age -->

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -105,7 +105,15 @@
         <%if v!=''%>
         <tr>
           <th><span class="attribute-label h4">Age</span></th>
-          <td><%= sanitize(v) %></td>
+          <td>
+            <% ages.each do |age| %>
+                <%= link_to  GenericLocalAuthorityService.id_to_label('age_of_learners',age.to_i),
+                           '/catalog?f[participants_age_sim][]='+age+'&locale=en&q=&search_field=all_fields',
+                           :target => "_blank"
+              %>
+               <br/>
+            <% end %>
+          </td>
         </tr>
         <%end%>
 

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -30,8 +30,15 @@
           <th><span class="attribute-label h4">Topic</span></th>
           <td>
             <% ras.each do |ra| %>
-                <%= GenericLocalAuthorityService.id_to_label('research_areas',ra.to_i) %><br/>
                 <% if GenericLocalAuthorityService.id_to_label('research_areas',ra.to_i).include? 'Other' %>
+                    <% if GenericLocalAuthorityService.id_to_label('research_areas',ra.to_i)!='Other' %>
+                        <%= link_to  GenericLocalAuthorityService.id_to_label('research_areas',ra.to_i),
+                                  '/catalog?f[research_areas_sim][]='+ra+'&locale=en&q=&search_field=all_fields',
+                                     :target => "_blank"
+                      %>
+                    <% else %>
+                        <%= GenericLocalAuthorityService.id_to_label('research_areas',ra.to_i) %><br/>
+                    <% end %>
                     <ul>
                       <%unless doc_presenter.document._source["summary_general_research_area_other_tesim"].nil?%>
                           <%doc_presenter.document._source["summary_general_research_area_other_tesim"].each do |w|%>
@@ -39,6 +46,12 @@
                           <%end%>
                       <%end%>
                     </ul>
+                <% else %>
+                    <%= link_to  GenericLocalAuthorityService.id_to_label('research_areas',ra.to_i),
+                                  '/catalog?f[research_areas_sim][]='+ra+'&locale=en&q=&search_field=all_fields',
+                                  :target => "_blank"
+                  %>
+                    <br/>
                 <% end %>
             <% end %>
           </td>

--- a/app/views/hyrax/base/_generic_field_with_authority.html.erb
+++ b/app/views/hyrax/base/_generic_field_with_authority.html.erb
@@ -7,9 +7,15 @@
           <%unless @presenter.solr_document._source[field_name+"_tesim"].nil?%>
             <%@presenter.solr_document._source[field_name+"_tesim"].each do |w|%>
               <% if w.to_i>0 %>
-                  <%=GenericLocalAuthorityService.id_to_label(authority_file_name, w.to_i)%><br/>
+                  <%= link_to  GenericLocalAuthorityService.id_to_label(authority_file_name, w.to_i),
+                             '/catalog?f['+field_name+'_sim][]='+w+'&locale=en&q=&search_field=all_fields',
+                             :target => "_blank"
+                             %><br/>
               <% else %>
-                  <%=GenericLocalAuthorityService.id_to_label(authority_file_name, w)%><br/>
+                  <%=  link_to  GenericLocalAuthorityService.id_to_label(authority_file_name, w),
+                              '/catalog?f['+field_name+'_sim][]='+w+'&locale=en&q=&search_field=all_fields',
+                              :target => "_blank"
+                              %><br/>
               <% end %>
               <%if 'Other' == GenericLocalAuthorityService.id_to_label(authority_file_name, w.to_i)%>
                 <%unless @presenter.solr_document._source[field_name+"_other_tesim"].nil?%>


### PR DESCRIPTION
Make all authority fields clickable in search result page and details page, the fields with free texts are excluded.