### PR TITLE
Issue 257 set pdf to download

### DIFF
--- a/app/forms/hyrax/summary_form.rb
+++ b/app/forms/hyrax/summary_form.rb
@@ -86,8 +86,11 @@ module Hyrax
           :visibility,
           :licence_agreement,
           :admin_set_id,
-          :member_of_collection_ids
+          :member_of_collection_ids,
+          :thumbnail_id,
+          :representative_id
       ]
     end
+
   end
 end

--- a/app/jobs/attach_files_to_work_job.rb
+++ b/app/jobs/attach_files_to_work_job.rb
@@ -1,0 +1,38 @@
+# Converts UploadedFiles into FileSets and attaches them to works.
+class AttachFilesToWorkJob < Hyrax::ApplicationJob
+  queue_as Hyrax.config.ingest_queue_name
+
+  # @param [ActiveFedora::Base] work - the work object
+  # @param [Array<Hyrax::UploadedFile>] uploaded_files - an array of files to attach
+  def perform(work, uploaded_files, **work_attributes)
+    validate_files!(uploaded_files)
+    user = User.find_by_user_key(work.depositor) # BUG? file depositor ignored
+    work_permissions = work.permissions.map(&:to_hash)
+    metadata = visibility_attributes(work_attributes)
+    uploaded_files.each do |uploaded_file|
+      actor = Hyrax::Actors::FileSetActor.new(FileSet.create, user)
+      actor.create_metadata(metadata)
+      actor.create_content(uploaded_file)
+      actor.attach_to_work(work)
+      actor.file_set.permissions_attributes = work_permissions
+      uploaded_file.update(file_set_uri: actor.file_set.uri)
+    end
+  end
+
+  private
+
+    # The attributes used for visibility - sent as initial params to created FileSets.
+    def visibility_attributes(attributes)
+      attributes.slice(:visibility, :visibility_during_lease,
+                       :visibility_after_lease, :lease_expiration_date,
+                       :embargo_release_date, :visibility_during_embargo,
+                       :visibility_after_embargo)
+    end
+
+    def validate_files!(uploaded_files)
+      uploaded_files.each do |uploaded_file|
+        next if uploaded_file.is_a? Hyrax::UploadedFile
+        raise ArgumentError, "Hyrax::UploadedFile required, but #{uploaded_file.class} received: #{uploaded_file.inspect}"
+      end
+    end
+end


### PR DESCRIPTION
Fixed issue 257:
1) if multiple files being uploaded, make sure the first file is PDF if exists
2) allow users to change thumbnail/representative media via file manager