### PR TITLE
Improve summary page view

### DIFF
--- a/app/helpers/show_summary_helper.rb
+++ b/app/helpers/show_summary_helper.rb
@@ -1,0 +1,40 @@
+# ShowSumamryHellper define handy methods such as check fields aviabaility
+module ShowSummaryHelper
+  def self.study_details?(presenter)
+    presenter.solr_document._source['participants_type_of_instruction_tesim'].nil? ||
+      presenter.solr_document._source['participants_type_of_instruction_tesim'][0] == '' &&
+      presenter.solr_document._source['participants_amount_of_instruction_tesim'].nil? ||
+      presenter.solr_document._source['participants_amount_of_instruction_tesim'][0] == '' &&
+      presenter.solr_document._source['summary_linguistictarget_tesim'].nil? ||
+      presenter.solr_document._source['summary_linguistictarget_tesim'][0] == ''
+  end
+
+  def self.participant_details?(presenter)
+    presenter.solr_document._source['participants_firstlanguage_tesim'].nil? ||
+      presenter.solr_document._source['participants_firstlanguage_tesim'][0] == '' &&
+      presenter.solr_document._source['participants_proficiency_tesim'].nil? ||
+      presenter.solr_document._source['participants_proficiency_tesim'][0] == '' &&
+      presenter.solr_document._source['participants_gender_tesim'].nil? ||
+      presenter.solr_document._source['participants_gender_tesim'][0] == '' &&
+      presenter.solr_document._source['participants_age_of_learners_of_arrival_tesim'].nil? ||
+      presenter.solr_document._source['participants_age_of_learners_of_arrival_tesim'][0] == '' &&
+      presenter.solr_document._source['participants_length_of_residence_tesim'].nil? ||
+      presenter.solr_document._source['participants_length_of_residence_tesim'][0] == '' &&
+      presenter.solr_document._source['participants_time_spent_using_l2_tesim'].nil? ||
+      presenter.solr_document._source['participants_time_spent_using_l2_tesim'][0] == '' &&
+      presenter.solr_document._source['participants_domain_of_use_tesim'].nil? ||
+      presenter.solr_document._source['participants_domain_of_use_tesim'][0] == '' &&
+      presenter.solr_document._source['participants_year_of_teaching_experience_tesim'].nil? ||
+      presenter.solr_document._source['participants_year_of_teaching_experience_tesim'][0] == '' &&
+      presenter.solr_document._source['participants_amount_of_prior_instruction_tesim'].nil? ||
+      presenter.solr_document._source['participants_amount_of_prior_instruction_tesim'][0] == '' &&
+      presenter.solr_document._source['participants_country_tesim'].nil? ||
+      presenter.solr_document._source['participants_country_tesim'][0] == '' &&
+      presenter.solr_document._source['participants_subnational_region_tesim'].nil? ||
+      presenter.solr_document._source['participants_subnational_region_tesim'][0] == '' &&
+      presenter.solr_document._source['participants_educational_stage_tesim'].nil? ||
+      presenter.solr_document._source['participants_educational_stage_tesim'][0] == '' &&
+      presenter.solr_document._source['participants_institutional_characteristics_tesim'].nil? ||
+      presenter.solr_document._source['participants_institutional_characteristics_tesim'][0] == ''
+  end
+end

--- a/app/views/hyrax/base/_licence.html.erb
+++ b/app/views/hyrax/base/_licence.html.erb
@@ -5,9 +5,6 @@
         </div>
 
         <div class="col-sm-9" style="vertical-align: middle;">
-          <%= link_to image_tag('by-nc-sa.eu.svg', height:32), 'https://creativecommons.org/licenses/by-nc-sa/4.0/', target: :_blank%>
+          <%= link_to 'Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)', 'https://creativecommons.org/licenses/by-nc-sa/4.0/', target: :_blank%>
         </div>
     </div>
-
-
-

--- a/app/views/hyrax/base/_title_of_summary.erb
+++ b/app/views/hyrax/base/_title_of_summary.erb
@@ -1,13 +1,15 @@
 <%unless @presenter.solr_document.title_of_summary.nil? %>
-    <div class="row">
-      <div class="col-sm-8">
-            <h2><%= @presenter.solr_document.title_of_summary %>
-              <%= image_tag("openaccess.png", :alt => "Open Access", class: "openaccess_logo") %>
-              <small class="text-muted"><%= presenter.permission_badge %> <%= presenter.workflow.badge %></small>
-            </h2>
-      </div>
-      <div class="col-sm-4 text-right">
-        <%= render "show_actions", presenter: presenter %>
-      </div>
+  <div class="row">
+    <div class="col-sm-8">
+      <h2><%= @presenter.solr_document.title_of_summary %>
+        <%= image_tag("openaccess.png", :alt => "Open Access", class: "openaccess_logo") %>
+        <%= link_to image_tag('by-nc-sa.eu.svg', height:32), 'https://creativecommons.org/licenses/by-nc-sa/4.0/', target: :_blank%>
+        <small class="text-muted"><%= presenter.permission_badge %>
+          <%= presenter.workflow.badge %></small>
+      </h2>
     </div>
+    <div class="col-sm-4 text-right">
+      <%= render "show_actions", presenter: presenter %>
+    </div>
+  </div>
 <% end %>

--- a/app/views/hyrax/summaries/_show_summary.html.erb
+++ b/app/views/hyrax/summaries/_show_summary.html.erb
@@ -1,6 +1,6 @@
 <div class="row work-type">
   <div class="col-xs-12">&nbsp;</div>
-  <div itemscope itemtype="http://schema.org/CreativeWork" class="col-xs-12">
+  <div itemscope="itemscope" itemtype="http://schema.org/CreativeWork" class="col-xs-12">
     <div class="panel panel-default">
       <div class="panel-heading">
         <%= render 'title_of_summary', presenter: @presenter %>
@@ -12,91 +12,95 @@
           <div class="col-sm-3 text-center">
             <%= render 'representative_media', presenter: @presenter, viewer: true %>
             <%#= render 'citations', presenter: @presenter %>
-            <%= render 'social_media' %>
+              <%= render 'social_media' %>
+            </div>
+            <div class="col-sm-9">
+              <div id="summary-details" class="detail_page_section_block">
+                <h4>Summary details</h4>
+                <hr/>
+                <%= render :partial => 'publication' %>
+                <!-- Writer of Summary -->
+                <%= render :partial => 'summary_writer' %>
+                <%= render :partial => 'upload_date' %>
+                <!-- Research Area -->
+                <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'summary_general_research_area', :authority_file_name => 'research_areas'} %>
+                <!-- Language Summary Written in -->
+                <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'language_summary_written_in', :authority_file_name => 'language_summary_written_in'} %>
+                <!-- Participant Type -->
+                <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'participants_type', :authority_file_name => 'participant_types'} %>
+                <!-- Language Being Learned -->
+                <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'participants_targetlanguage', :authority_file_name => 'languages_being_learned'} %>
+                <!-- Age of Learners -->
+                <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'participants_age', :authority_file_name => 'age_of_learners'} %>
+                <!-- Materials on IRIS -->
+                <%= render :partial => 'materials_on_iris' %>
+                <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'of_likely_interest_to', :authority_file_name => 'of_likely_interest_to'} %>
+                <%= render :partial => 'licence' %>
+              </div>
+
+              <% unless ShowSummaryHelper.participant_details?(@presenter) %>
+                <button type="button" class="btn btn-info accordian_title" data-toggle="collapse" data-target="#participant-details">More participant details</button>
+                <br/>
+                <div id="participant-details" class="detail_page_section_block collapse">
+                  <!-- First Language of Learners -->
+                  <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'participants_firstlanguage', :authority_file_name => 'first_language_of_learners'} %>
+                  <!-- Proficiency of Learners -->
+                  <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'participants_proficiency', :authority_file_name => 'proficiency_of_learners'} %>
+                  <!-- Gender of Learners -->
+                  <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'participants_gender', :authority_file_name => 'gender_of_learners'} %>
+                  <!-- Age of Learners at Arrival -->
+                  <%= render :partial => 'generic_field', :locals => {:field_name => 'participants_age_of_learners_of_arrival'} %>
+                  <!-- Length of Residence of Learners -->
+                  <%= render :partial => 'generic_field', :locals => {:field_name => 'participants_length_of_residence'} %>
+                  <!-- Time Spent Using the L2 -->
+                  <%= render :partial => 'generic_field', :locals => {:field_name => 'participants_time_spent_using_l2'} %>
+                  <!-- Contex of language use -->
+                  <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'participants_domain_of_use', :authority_file_name => 'domains_of_use'} %>
+                  <!-- Years of teaching experience -->
+                  <%= render :partial => 'generic_field', :locals => {:field_name => 'participants_year_of_teaching_experience'} %>
+                  <!-- Amunt of prior instruction -->
+                  <%= render :partial => 'generic_field', :locals => {:field_name => 'participants_amount_of_prior_instruction'} %>
+                  <!-- Context of language use -->
+
+                  <!-- participants_country -->
+                  <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'participants_country', :authority_file_name => 'country_code'} %>
+
+                  <%= render :partial => 'generic_field', :locals => {:field_name => 'participants_subnational_region'} %>
+
+                  <!-- participants_educational_stage -->
+                  <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'participants_educational_stage', :authority_file_name => 'educational_stage'} %>
+
+                  <!-- participants_institutional_characteristics -->
+                  <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'participants_institutional_characteristics', :authority_file_name => 'institutional_characteristics'} %>
+                </div>
+                <br/>
+              <% end %>
+
+              <% unless ShowSummaryHelper.study_details?(@presenter) %>
+                <button type="button" class="btn btn-info accordian_title" data-toggle="collapse" data-target="#study-details">More study details</button>
+                <div id="study-details" class="detail_page_section_block collapse">
+                  <!-- Language feature -->
+                  <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'summary_linguistictarget', :authority_file_name => 'language_features'} %>
+                  <!-- Type of Instruction -->
+                  <%= render :partial => 'generic_field', :locals => {:field_name => 'participants_type_of_instruction'} %>
+                  <!-- Amount of Instruction -->
+                  <%= render :partial => 'generic_field', :locals => {:field_name => 'participants_amount_of_instruction'} %>
+                </div>
+                <br/>
+              <% end %>
+
+              <div id="cite_summary" class="detail_page_section_block">
+                <%= render :partial => 'cite_summary' %>
+              </div>
+            </div>
+            <div class="col-sm-12">
+              <%#= render 'items', presenter: @presenter %>
+                <%# TODO: we may consider adding these partials in the future %>
+                  <%#= render 'sharing_with', presenter: @presenter %>
+                    <%#= render 'user_activity', presenter: @presenter %>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
-          <div class="col-sm-9">
-            <div id="summary-details" class="detail_page_section_block">
-              <h4>Summary details</h4>
-              <hr/>
-              <%= render :partial => 'publication' %>
-              <!-- Writer of Summary -->
-              <%= render :partial => 'summary_writer' %>
-              <%= render :partial => 'upload_date' %>
-              <!-- Research Area -->
-              <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'summary_general_research_area', :authority_file_name => 'research_areas'} %>
-              <!-- Language Summary Written in -->
-              <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'language_summary_written_in', :authority_file_name => 'language_summary_written_in'} %>
-              <!-- Participant Type -->
-              <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'participants_type', :authority_file_name => 'participant_types'} %>
-              <!-- Language Being Learned -->
-              <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'participants_targetlanguage', :authority_file_name => 'languages_being_learned'} %>
-              <!-- Age of Learners -->
-              <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'participants_age', :authority_file_name => 'age_of_learners'} %>
-              <!-- Materials on IRIS -->
-              <%= render :partial => 'materials_on_iris' %>
-              <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'of_likely_interest_to', :authority_file_name => 'of_likely_interest_to'} %>
-              <%= render :partial => 'licence' %>
-            </div>
-
-            <button type="button" class="btn btn-info accordian_title" data-toggle="collapse" data-target="#participant-details">More participant details</button>
-            <br/>
-            <div id="participant-details" class="detail_page_section_block collapse">
-              <!-- First Language of Learners -->
-              <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'participants_firstlanguage', :authority_file_name => 'first_language_of_learners'} %>
-              <!-- Proficiency of Learners -->
-              <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'participants_proficiency', :authority_file_name => 'proficiency_of_learners'} %>
-              <!-- Gender of Learners -->
-              <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'participants_gender', :authority_file_name => 'gender_of_learners'} %>
-              <!-- Age of Learners at Arrival -->
-              <%= render :partial => 'generic_field', :locals => {:field_name => 'participants_age_of_learners_of_arrival'} %>
-              <!-- Length of Residence of Learners -->
-              <%= render :partial => 'generic_field', :locals => {:field_name => 'participants_length_of_residence'} %>
-              <!-- Time Spent Using the L2 -->
-              <%= render :partial => 'generic_field', :locals => {:field_name => 'participants_time_spent_using_l2'} %>
-              <!-- Contex of language use -->
-              <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'participants_domain_of_use', :authority_file_name => 'domains_of_use'} %>
-              <!-- Years of teaching experience -->
-              <%= render :partial => 'generic_field', :locals => {:field_name => 'participants_year_of_teaching_experience'} %>
-              <!-- Amunt of prior instruction -->
-              <%= render :partial => 'generic_field', :locals => {:field_name => 'participants_amount_of_prior_instruction'} %>
-              <!-- Context of language use  -->
-
-              <!-- participants_country -->
-              <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'participants_country', :authority_file_name => 'country_code'} %>
-
-              <%= render :partial => 'generic_field', :locals => {:field_name => 'participants_subnational_region'} %>
-
-              <!-- participants_educational_stage -->
-              <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'participants_educational_stage', :authority_file_name => 'educational_stage'} %>
-
-              <!-- participants_institutional_characteristics -->
-              <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'participants_institutional_characteristics', :authority_file_name => 'institutional_characteristics'} %>
-            </div>
-            <br/>
-
-            <button type="button" class="btn btn-info accordian_title" data-toggle="collapse" data-target="#study-details">More study details</button>
-            <div id="study-details" class="detail_page_section_block collapse">
-              <!-- Language feature -->
-              <%= render :partial => 'generic_field_with_authority', :locals => {:field_name => 'summary_linguistictarget', :authority_file_name => 'language_features'} %>
-              <!-- Type of Instruction -->
-              <%= render :partial => 'generic_field', :locals => {:field_name => 'participants_type_of_instruction'} %>
-              <!-- Amount of Instruction -->
-              <%= render :partial => 'generic_field', :locals => {:field_name => 'participants_amount_of_instruction'} %>
-            </div>
-            <br/>
-
-            <div id ="cite_summary" class="detail_page_section_block">
-              <%= render :partial => 'cite_summary' %>
-            </div>
-          </div>
-          <div class="col-sm-12">
-            <%#= render 'items', presenter: @presenter %>
-            <%# TODO: we may consider adding these partials in the future %>
-            <%#= render 'sharing_with', presenter: @presenter %>
-            <%#= render 'user_activity', presenter: @presenter %>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>


### PR DESCRIPTION
This change is to make summary page view more cleaner as discussed at #275.

- Move licence icon in title space
- Add full licence text
- Make conditional display of Participants details section
- make conditional display of Study details section