### PR TITLE
Correct search filter: Summary models only

### DIFF
--- a/app/search_builders/oasis/oasis_search_builder.rb
+++ b/app/search_builders/oasis/oasis_search_builder.rb
@@ -26,7 +26,7 @@ module Oasis
 
     # Only query Summaries
     def only_search_summary(solr_parameters)
-      solr_parameters[:qf] += ' has_model_ssim:Summary'
+      solr_parameters[:fq] << "{!field f=has_model_ssim}#{Summary}"
     end
   end
 end


### PR DESCRIPTION
One more attempt to correct search filter. Follow Hyrax [documentation](http://samvera.github.io/building-searches.html) -  filter records with Summary model only