### PR TITLE
Disable use of Turbolinks

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,8 +10,8 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//=
-//= require turbolinks
+//Turbolinks does not work with our JQuery oasis.js. Using jquery.turbolinks gem will not solve the issue.
+//require turbolinks
 //
 // Required by Blacklight
 //= require jquery


### PR DESCRIPTION
Turbolinks does not work with our JQuery oasis.js. The upload-form will not work as expected:
- other journals fields
- hidden *_all form data
- reordering authors and writers fields

Using jquery.turbolinks gem will not solve the issue. Using page on.load event will not solve the issue.
- https://thoughtbot.com/upcase/videos/turbolinks
- https://github.com/kossnocorp/jquery.turbolinks