### PR TITLE
Bugfix/jira lan 50/video html5 display

### DIFF
--- a/app/helpers/hyrax/file_set_helper.rb
+++ b/app/helpers/hyrax/file_set_helper.rb
@@ -1,0 +1,35 @@
+module Hyrax::FileSetHelper
+  def parent_path(parent)
+    if parent.is_a?(Collection)
+      main_app.collection_path(parent)
+    else
+      polymorphic_path([main_app, parent])
+    end
+  end
+
+  # REVIEW: Since this media display could theoretically work for
+  #         any object that inplements to_s and the Mime Type methos (image? audio? ...),
+  #         Should this really be in file_set or could it be in it's own helper class like media_helper?
+  def media_display(presenter, locals = {})
+    render media_display_partial(presenter),
+           locals.merge(file_set: presenter)
+  end
+
+  def media_display_partial(file_set)
+    'hyrax/file_sets/media_display/' +
+      if file_set.image?
+        'image'
+      elsif file_set.video?
+        'video'
+      elsif file_set.audio?
+        'audio'
+      elsif file_set.pdf?
+        'pdf'
+      elsif file_set.office_document?
+        'office_document'
+      else
+        'default'
+      end
+  end
+  # rubocop:enable Metrics/MethodLength
+end

--- a/app/helpers/hyrax/file_set_helper.rb
+++ b/app/helpers/hyrax/file_set_helper.rb
@@ -19,7 +19,7 @@ module Hyrax::FileSetHelper
     'hyrax/file_sets/media_display/' +
       if file_set.image?
         'image'
-      elsif file_set.video?
+      elsif file_set.video? || file_set.mime_type == 'application/mp4'
         'video'
       elsif file_set.audio?
         'audio'

--- a/app/views/hyrax/file_sets/media_display/_video.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_video.html.erb
@@ -1,6 +1,6 @@
   <video controls="controls" class="video-js vjs-default-skin" data-setup="{}" preload="auto">
-    <source src="<%= hyrax.download_path(file_set, file: 'webm') %>" type="video/webm" />
-    <source src="<%= hyrax.download_path(file_set, file: 'mp4') %>" type="video/mp4" />
+    <source src="<%= hyrax.download_path(file_set) %>" type="video/webm" />
+    <source src="<%= hyrax.download_path(file_set) %>" type="video/mp4" />
     Your browser does not support the video tag.
   </video>
 

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -63,7 +63,7 @@ Hyrax.config do |config|
   # config.persistent_hostpath = 'http://localhost/files/'
 
   # If you have ffmpeg installed and want to transcode audio and video set to true
-  # config.enable_ffmpeg = false
+  config.enable_ffmpeg = true
 
   # Hyrax uses NOIDs for files and collections instead of Fedora UUIDs
   # where NOID = 10-character string and UUID = 32-character string w/ hyphens


### PR DESCRIPTION
Rudimentary fix for JIRA [LAN-50](https://dti-uoy.atlassian.net/browse/LAN-50)

# Known Issues
- Video download button will not show as it is not developed
- Streaming video will not trigger download statistics as this is not developed
- Video box on file_manager display overrun metadata box - styling required