### PR TITLE
Docker use precompiled assets

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,8 +72,6 @@ services:
       interval: 30s
       timeout: 5s
       retries: 3
-    volumes:
-      - postgresdb:/var/lib/postgresql/data
     networks:
       internal:
     expose:

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -16,22 +16,22 @@ fi
 
 # bundle exec rake leaf_addons:db:setup_and_migrate
 
-# echo "Checking for new assets ... "
+echo "Checking for new assets ... "
 
-# if [[ -d $APP_WORKDIR/public/assets && -f $APP_WORKDIR/shared/assets_hash ]]; then
-#   find public/assets -type f | sort | xargs md5sum | cut -c1-32 | md5sum | cut -c1-32 > $APP_WORKDIR/assets_hash
-#   echo $(cat $APP_WORKDIR/assets_hash)
-#   echo $(cat $APP_WORKDIR/shared/assets_hash)
-#   if [[ "$(cat $APP_WORKDIR/assets_hash)" != "$(cat $APP_WORKDIR/shared/assets_hash)" ]]; then
-#     echo "Running rake assets:precompile to update assets... "
-#     bundle exec rake assets:precompile
-#     mv assets_hash $APP_WORKDIR/shared/
-#   else
-#     echo "No changes to assets ..."
-#     rm $APP_WORKDIR/assets_hash
-#   fi
-# else
-#   echo "Running rake assets:precompile ... "
-#   bundle exec rake assets:precompile
-#   find public/assets -type f | sort | xargs md5sum | cut -c1-32 | md5sum | cut -c1-32 > $APP_WORKDIR/shared/assets_hash
-# fi
+if [[ -d $APP_WORKDIR/public/assets && -f $APP_WORKDIR/shared/assets_hash ]]; then
+  find public/assets -type f | sort | xargs md5sum | cut -c1-32 | md5sum | cut -c1-32 > $APP_WORKDIR/assets_hash
+  echo $(cat $APP_WORKDIR/assets_hash)
+  echo $(cat $APP_WORKDIR/shared/assets_hash)
+  if [[ "$(cat $APP_WORKDIR/assets_hash)" != "$(cat $APP_WORKDIR/shared/assets_hash)" ]]; then
+    echo "Running rake assets:precompile to update assets... "
+    bundle exec rake assets:precompile
+    mv assets_hash $APP_WORKDIR/shared/
+  else
+    echo "No changes to assets ..."
+    rm $APP_WORKDIR/assets_hash
+  fi
+else
+  echo "Running rake assets:precompile ... "
+  bundle exec rake assets:precompile
+  find public/assets -type f | sort | xargs md5sum | cut -c1-32 | md5sum | cut -c1-32 > $APP_WORKDIR/shared/assets_hash
+fi


### PR DESCRIPTION
Use precompiled assets in local development. It helps with trouble shutting JS errors.