### PR TITLE
Security fix: Bump up tzinfo-data version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ group :development do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'tzinfo-data', '~> 1.2.10', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'browse-everything', '~> 0.16.1'
 gem 'hyrax', '~> 2.9.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -927,10 +927,10 @@ DEPENDENCIES
   sqlite3
   therubyracer
   turbolinks (~> 5)
-  tzinfo-data
+  tzinfo-data (~> 1.2.10)
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
   xray-rails
 
 BUNDLED WITH
-   2.3.7
+   2.3.18


### PR DESCRIPTION
Resolves Dependabot alert [30](https://github.com/digital-york/oasis/security/dependabot/30)