### PR TITLE
Disable open access facet sorting

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -66,7 +66,7 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name('publication_journal_name', :facetable), label: "Journal of publication", limit: 5
     config.add_facet_field solr_name('publication_date', :facetable), label: "Date of publication", limit: 5
     config.add_facet_field solr_name('materials_on_iris', :facetable), label: "Materials on IRIS", limit: 5
-    config.add_facet_field solr_name('original_article_open_access', :facetable), label: "Original article open access", limit: 5
+    #config.add_facet_field solr_name('original_article_open_access', :facetable), label: "Original article open access", limit: 5
     config.add_facet_field solr_name('language_summary_written_in', :facetable), label: "Language summary written in", limit: 5
 
     # The generic_type isn't displayed on the facet list


### PR DESCRIPTION
- Summaries already present in the system have not been indicated if their original article is open access or not. This would not be displayed in the sidebar in the sorting hence. Till the time all the summaries are not indicted, the sorting may cause confusion showing only the latest ones that have indications included. Hence commenting out the facet sorting.