### PR TITLE
Feature - Add download stats tally at home page

### DIFF
--- a/app/controllers/hyrax/homepage_controller.rb
+++ b/app/controllers/hyrax/homepage_controller.rb
@@ -21,7 +21,7 @@ class Hyrax::HomepageController < ApplicationController
     @marketing_text = ContentBlock.for(:marketing)
     @featured_work_list = FeaturedWorkList.new
     @announcement_text = ContentBlock.for(:announcement)
-    @total_downloads = DownloadTallyHelper.total_downloads
+    @total_downloads = DownloadStatsHelper.total_downloads
     recent
   end
 

--- a/app/controllers/hyrax/homepage_controller.rb
+++ b/app/controllers/hyrax/homepage_controller.rb
@@ -21,29 +21,30 @@ class Hyrax::HomepageController < ApplicationController
     @marketing_text = ContentBlock.for(:marketing)
     @featured_work_list = FeaturedWorkList.new
     @announcement_text = ContentBlock.for(:announcement)
+    @total_downloads = DownloadTallyHelper.total_downloads
     recent
   end
 
   private
 
-    # Return 5 collections
-    def collections(rows: 5)
-      builder = Hyrax::CollectionSearchBuilder.new(self)
-                                              .rows(rows)
-      response = repository.search(builder)
-      response.documents
-    rescue Blacklight::Exceptions::ECONNREFUSED, Blacklight::Exceptions::InvalidRequest
-      []
-    end
+  # Return 5 collections
+  def collections(rows: 5)
+    builder = Hyrax::CollectionSearchBuilder.new(self)
+                                            .rows(rows)
+    response = repository.search(builder)
+    response.documents
+  rescue Blacklight::Exceptions::ECONNREFUSED, Blacklight::Exceptions::InvalidRequest
+    []
+  end
 
-    def recent
-      # grab any recent documents
-      (_, @recent_documents) = search_results(q: 'has_model_ssim:Summary', sort: sort_field, rows: 4)
-    rescue Blacklight::Exceptions::ECONNREFUSED, Blacklight::Exceptions::InvalidRequest
-      @recent_documents = []
-    end
+  def recent
+    # grab any recent documents
+    (_, @recent_documents) = search_results(q: 'has_model_ssim:Summary', sort: sort_field, rows: 4)
+  rescue Blacklight::Exceptions::ECONNREFUSED, Blacklight::Exceptions::InvalidRequest
+    @recent_documents = []
+  end
 
-    def sort_field
-      "#{Solrizer.solr_name('system_create', :stored_sortable, type: :date)} desc"
-    end
+  def sort_field
+    "#{Solrizer.solr_name('system_create', :stored_sortable, type: :date)} desc"
+  end
 end

--- a/app/helpers/download_stats_helper.rb
+++ b/app/helpers/download_stats_helper.rb
@@ -1,0 +1,10 @@
+module DownloadStatsHelper
+  def self.total_downloads
+    if Figaro.env.download_stats_json.nil?
+      '53,962'
+    else
+      json_string = File.read(Figaro.env.download_stats_json)
+      JSON.parse(json_string)['total_downloads']
+    end
+  end
+end

--- a/app/helpers/download_stats_helper.rb
+++ b/app/helpers/download_stats_helper.rb
@@ -4,7 +4,8 @@ module DownloadStatsHelper
       '53,962'
     else
       json_string = File.read(Figaro.env.download_stats_json)
-      JSON.parse(json_string)['total_downloads']
+      # Read number and format it with comma every thousend 
+      JSON.parse(json_string)['total_downloads'].to_s.reverse.gsub(/(\d{3})(?=\d)/, '\1,').reverse
     end
   end
 end

--- a/app/views/hyrax/homepage/_download_stats.erb
+++ b/app/views/hyrax/homepage/_download_stats.erb
@@ -1,0 +1,5 @@
+<div style="border: 1px solid white;border-radius: 5px;background: #286090;padding: 10px;">
+  <div>
+    <h4 style="color: white">Number of total downloads: <%= @total_downloads %></h4>
+  </div>
+</div>

--- a/app/views/hyrax/homepage/_download_stats.erb
+++ b/app/views/hyrax/homepage/_download_stats.erb
@@ -1,5 +1,6 @@
-<div style="border: 1px solid white;border-radius: 5px;background: #286090;padding: 10px;">
-  <div>
-    <h4 style="color: white">Number of total downloads: <%= @total_downloads %></h4>
+<div style="border: 1px solid white;border-radius: 15px;background: #286090;padding-top: 10px;">
+  <div class="text-center">
+    <p style="color: white">Total number of summaries downloaded</p>
+    <h4 style="color: white"><%= @total_downloads %></h4>
   </div>
 </div>

--- a/app/views/hyrax/homepage/index.html.erb
+++ b/app/views/hyrax/homepage/index.html.erb
@@ -70,6 +70,9 @@
   <%= render 'alerts' %>
   <br/>
 
+  <%= render 'download_stats' %>
+  <br/>
+
   <h4>Recently uploaded</h4>
   <%= render 'recently_uploaded', recent_documents: @recent_documents %>
   <br/>

--- a/app/views/hyrax/homepage/index.html.erb
+++ b/app/views/hyrax/homepage/index.html.erb
@@ -2,9 +2,17 @@
 
 <div class="row home-content">
   <h4>Welcome to OASIS</h4>
-  <p>The OASIS database makes research on language learning, use, and education available and accessible to a wide audience.</p>
+  
+  <div class="row">
+    <div class="col-md-8">
+      <p>The OASIS database makes research on language learning, use, and education available and accessible to a wide audience.</p>
+    </div>
+    <div class="col-md-4">
+      <%= render 'download_stats' %>
+    </div>
+  </div>
   <br/>
-
+  
   <h4>Search OASIS</h4>
 
   <%= render partial: 'catalog/homepage_search_form' %>
@@ -68,9 +76,6 @@
   <br/>
 
   <%= render 'alerts' %>
-  <br/>
-
-  <%= render 'download_stats' %>
   <br/>
 
   <h4>Recently uploaded</h4>


### PR DESCRIPTION
Resolves [LAN-35](https://dti-uoy.atlassian.net/browse/LAN-35)

_download_stats_helper.rb_ - add helper method to get total downloads count
- It expect that application.yml defines _download_stats_json_
- JSON file is in form of { total_downloads: XXX }
- If JSON not defined it will show default value for total downloads 

_index.html.erb_ - render download stats view on homepage 

_download_stats.erb_ - add view to display total downloads count 

_homepage_controller.rb_ - add total downloads count to homepage

**WIP** generation of download_stats.json file. This will be part of cron task that will run [python script using google-analytics-data library.](https://github.com/digital-york/language-gateways-ga-tools) The script will be using credentials generated via Google Cloud console and saved as credentials.json file. All must be deployed to staging/production server.